### PR TITLE
Fix DenseElementsAttr dumping

### DIFF
--- a/mlir/astnodes.py
+++ b/mlir/astnodes.py
@@ -435,7 +435,7 @@ class DenseElementsAttr(ElementsAttr):
     type: Union[TensorType, VectorType]
 
     def dump(self, indent: int = 0) -> str:
-        return 'dense<%s> : %s' % (self.attribute.dump(indent),
+        return 'dense<%s> : %s' % (dump_or_value(self.attribute, indent),
                                    self.type.dump(indent))
 
 


### PR DESCRIPTION
Constant literal type attributes need dump_or_value to dump properly