### PR TITLE
Fix parsing for type aliases

### DIFF
--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -27,6 +27,7 @@ tensor_literal: constant_literal | "[" "]" | "[" tensor_literal ("," tensor_lite
 
 // Identifier syntax
 bare_id : (letters | underscore) (letters | digits | underscore | id_chars)*
+alias_id : (letters | underscore) (letters | digits | underscore)*
 suffix_id : digits | ((letters | id_punct) (letters | id_punct | digits)*)
 
 // Dimensions
@@ -42,9 +43,9 @@ dimension_list : dimension_list_ranked | dimension_list_unranked
 ssa_id        : "%" suffix_id ("#" digits)?
 symbol_ref_id : "@" (suffix_id | string_literal)
 block_id      : "^" suffix_id
-type_alias     : "!" (string_literal | bare_id)
+type_alias     : "!" (string_literal | alias_id)
 map_or_set_id : "#" suffix_id
-attribute_alias : "#" (string_literal | bare_id)
+attribute_alias : "#" (string_literal | alias_id)
 
 ssa_id_list : ssa_id ("," ssa_id)*
 

--- a/mlir/parser_transformer.py
+++ b/mlir/parser_transformer.py
@@ -39,6 +39,10 @@ class TreeToMlir(Transformer):
         return ''.join(str(s) for s in elements)
 
     @v_args(inline=True)
+    def alias_id(self, *elements):
+        return ''.join(str(s) for s in elements)
+
+    @v_args(inline=True)
     def suffix_id(self, *suffix):
         return ''.join(str(s) for s in suffix)
 


### PR DESCRIPTION
Type aliases explicitly disallows "." in the type alias id https://mlir.llvm.org/docs/LangRef/#type-aliases and https://mlir.llvm.org/docs/LangRef/#attribute-value-aliases

This was causing a bug where a type alias followed by a dialect operation with no result was being fused:

```
...
} : !type_alias
func.return
```
was being parsed as a type alias with name "type_aliasfunc."

