### PR TITLE
Fix Type Alias parsing

### DIFF
--- a/mlir/lark/mlir.lark
+++ b/mlir/lark/mlir.lark
@@ -43,7 +43,7 @@ dimension_list : dimension_list_ranked | dimension_list_unranked
 ssa_id        : "%" suffix_id ("#" digits)?
 symbol_ref_id : "@" (suffix_id | string_literal)
 block_id      : "^" suffix_id
-type_alias     : "!" (string_literal | alias_id)
+type_alias     : "!" alias_id
 map_or_set_id : "#" suffix_id
 attribute_alias : "#" (string_literal | alias_id)
 
@@ -349,3 +349,4 @@ mlir_file: definition_and_function_list*       -> only_functions_and_definitions
 
 COMMENT : "//" /(.)*/ NEWLINE
 %ignore COMMENT
+


### PR DESCRIPTION
string_literal as a type alias name with ignore whitespace set causes incorrect parsing of type alias if followed by an operation with no results. 

e.g.:
... : !type_alias

func.return